### PR TITLE
Refine process by which news article text is trimmed for on-site news…

### DIFF
--- a/src/routes/news/[slug]/+page.svelte
+++ b/src/routes/news/[slug]/+page.svelte
@@ -12,7 +12,26 @@ Here's some documentation for this component.
 	// data
 	let { data } = $props(); // data coming in from page.ts LoadEvent
 
-	// formatted markup
+	// variables
+	let onPageArticleBody = truncateArticleText(data.article.text.html, 2);
+
+	// functions
+	function truncateArticleText(text: string, length: number): string {
+		let textArray: string[] = text.split("</p>");
+		if (textArray.length > length) {
+			textArray = textArray.slice(0, length + 1);
+			let lastSegment = textArray[length]; // This will always exist if textArray.length > length
+			if (lastSegment !== undefined) {
+				let trimmingIndex = lastSegment.lastIndexOf(".");
+				if (trimmingIndex > 0) {
+					textArray[length] = lastSegment.slice(0, trimmingIndex);
+				}
+			}
+			return textArray.join("</p>") + "...";
+		} else {
+			return text;
+		}
+	}
 </script>
 
 <template lang="pug">
@@ -72,7 +91,7 @@ Here's some documentation for this component.
 					p.mb-4.text-17.italic.opacity-80.text-neutral-100 { data?.article.excerpt }
 					//- prettier-ignore
 					#article-text.text-18.leading-relaxed.mb-8(class="md:text-[18px]")
-						+html('data.article?.text?.html?.substring(0,1200) ?? "" + "... " ')
+						+html('onPageArticleBody ?? "" + "... " ')
 
 						i.opacity-80.text-16 ( article continues at { data.article?.source?.name ? data.article?.source?.name : "" } )
 


### PR DESCRIPTION
This is made from a fresh clone of verde-web repo.

It should be pretty reliable because it was already the case that the source string is HTML that gets parsed in the template;  instead of needing character-by-character logic to parse where the paragraphs are, its first step is just splitting the source string at "</p>".  

The function that does this allows the developer to set the number of paragraphs displayed.  I set it to 3.

I checked the results on about 20 articles.  There's some logic in there that looks possibly extraneous but it's just there to shave off irregularities like a space after the final "." which messed things up in one article that I checked.