### PR TITLE
Refine on page news presentation

### DIFF
--- a/src/routes/news/[slug]/+page.server.ts
+++ b/src/routes/news/[slug]/+page.server.ts
@@ -11,6 +11,7 @@ export const load: PageServerLoad = async function ({ locals, params, url }) {
 	// const article = articles.find((article) => article.slug === slug);
 	const articleIndex = articles.findIndex((article) => article.slug === slug);
 	const article = articles[articleIndex];
+	const onPageArticleText = truncateArticleText(article.text?.html ?? "");
 	const nextArticle = articles[articleIndex + 1];
 	const nextArticleSlug = nextArticle ? nextArticle.slug : articles[0].slug;
 	const nextArticleTitle = nextArticle
@@ -22,6 +23,86 @@ export const load: PageServerLoad = async function ({ locals, params, url }) {
 		return utils.redirect(404);
 	}
 
+	// functions
+	function truncateArticleText(
+		// limits the text to a certain number of characters and a certain number of paragraphs
+		// if character limit is set too low, strange things might happen.
+		text: string,
+		characterLimit = 1400,
+		grafLimit = 3,
+	) {
+		// truncateArticleText helper function to raise the character limit for anchor elements in the text--they don't render but they DO deplete the character allowance
+		function raiseLimitForAnchorElements(
+			text: string,
+			searchStartIndex = 0,
+			searchEndIndex = characterLimit,
+		) {
+			// search for anchor elements from the beginning of the text to the limit
+			// if anchor found, raise the character limit by the length of the entire anchor element, even if the end of the element is beyond the character limit
+			// use recursion to search for more anchor elements that might start between the end of the first anchor and the newly increased limit
+			let excerpt = text.slice(searchStartIndex, searchEndIndex);
+			let startOfAnchor = excerpt.indexOf("<a ");
+			if (startOfAnchor === -1) return;
+			else {
+				startOfAnchor += searchStartIndex;
+				let endOfAnchor =
+					text.slice(searchStartIndex).indexOf("</a>") + 3 + searchStartIndex;
+				let anchorLength = endOfAnchor - startOfAnchor;
+				characterLimit += anchorLength;
+				return raiseLimitForAnchorElements(
+					text,
+					endOfAnchor + searchStartIndex,
+					characterLimit,
+				);
+			}
+		}
+
+		// truncateArticleText helper function to clean the end of the last graf so we don't get a "...." or a ". ..." or what have you at the end of the excerpt
+		function cleanEnd(lastGraf: string) {
+			let trimmingIndex =
+				lastGraf.lastIndexOf(".") > 0
+					? lastGraf.lastIndexOf(".")
+					: lastGraf.lastIndexOf(" ");
+			return trimmingIndex > 0 ? lastGraf.slice(0, trimmingIndex) : lastGraf;
+		}
+
+		// truncateArticleText helper function to apply the character limit to the text
+		function applyCharacterLimit(text: string) {
+			raiseLimitForAnchorElements(text);
+
+			let limitedText =
+				text.length > characterLimit ? text.slice(0, characterLimit) : text;
+			return limitedText;
+		}
+
+		let characterLimitedText = applyCharacterLimit(text);
+
+		// with the character count of our excerpt limited to account for the possibility of an article with no paragraph breaks, we now split our excerpt at the paragraph breaks that probably DO exist, and limit the number of paragraphs to the number specified in the grafLimit parameter
+		let textArray: string[] = characterLimitedText.split("</p>");
+		// filter out possible empty paragraphs.  It seems that Hygraph turns carriage returns into HTML paragraph tags, so they are easily produced by accident.
+		textArray = textArray.filter((graf) => graf !== "<p>");
+
+		if (textArray.length > grafLimit) {
+			textArray = textArray.slice(0, grafLimit);
+			if (
+				textArray[grafLimit - 1] !== null &&
+				textArray[grafLimit - 1] !== undefined
+			)
+				textArray[grafLimit - 1] = cleanEnd(textArray[grafLimit - 1]);
+			return textArray.join("</p>") + "...";
+		} else if (textArray.length > 1 && textArray.length <= grafLimit) {
+			// if the textArray length is at or under the limit, it is overwhelmingly likely that the last graf is incomplete and cuts out awkwardly, so we dump it
+			textArray.length -= 1;
+			textArray[textArray.length - 1] = cleanEnd(
+				textArray[textArray.length - 1],
+			);
+			return textArray.join("</p>") + "...";
+		} else {
+			// if the textArray length is 1, it's almost certain that the article is a single paragraph, so we just clean the end and return it
+			return cleanEnd(characterLimitedText) + "...";
+		}
+	}
+
 	const meta = {
 		title: article.headline,
 		description: article.excerpt,
@@ -31,6 +112,7 @@ export const load: PageServerLoad = async function ({ locals, params, url }) {
 
 	return {
 		article,
+		onPageArticleText,
 		nextArticleSlug,
 		nextArticleTitle,
 		meta,

--- a/src/routes/news/[slug]/+page.svelte
+++ b/src/routes/news/[slug]/+page.svelte
@@ -11,27 +11,6 @@ Here's some documentation for this component.
 
 	// data
 	let { data } = $props(); // data coming in from page.ts LoadEvent
-
-	// variables
-	let onPageArticleBody = truncateArticleText(data.article.text.html, 2);
-
-	// functions
-	function truncateArticleText(text: string, length: number): string {
-		let textArray: string[] = text.split("</p>");
-		if (textArray.length > length) {
-			textArray = textArray.slice(0, length + 1);
-			let lastSegment = textArray[length]; // This will always exist if textArray.length > length
-			if (lastSegment !== undefined) {
-				let trimmingIndex = lastSegment.lastIndexOf(".");
-				if (trimmingIndex > 0) {
-					textArray[length] = lastSegment.slice(0, trimmingIndex);
-				}
-			}
-			return textArray.join("</p>") + "...";
-		} else {
-			return text;
-		}
-	}
 </script>
 
 <template lang="pug">
@@ -91,7 +70,8 @@ Here's some documentation for this component.
 					p.mb-4.text-17.italic.opacity-80.text-neutral-100 { data?.article.excerpt }
 					//- prettier-ignore
 					#article-text.text-18.leading-relaxed.mb-8(class="md:text-[18px]")
-						+html('onPageArticleBody ?? "" + "... " ')
+						+html('data.onPageArticleText')
+						//- +html('data.article.text.html ?? "" + "... " ')
 
 						i.opacity-80.text-16 ( article continues at { data.article?.source?.name ? data.article?.source?.name : "" } )
 

--- a/src/routes/news/[slug]/+page.svelte
+++ b/src/routes/news/[slug]/+page.svelte
@@ -12,7 +12,26 @@ Here's some documentation for this component.
 	// data
 	let { data } = $props(); // data coming in from page.ts LoadEvent
 
-	// formatted markup
+	// variables
+	let onPageArticleBody = truncateArticleText(data.article.text.html, 2);
+
+	// functions
+	function truncateArticleText(text: string, length: number): string {
+		let textArray: string[] = text.split("</p>");
+		if (textArray.length > length) {
+			textArray = textArray.slice(0, length + 1);
+			let lastSegment = textArray[length]; // This will always exist if textArray.length > length
+			if (lastSegment !== undefined) {
+				let trimmingIndex = lastSegment.lastIndexOf(".");
+				if (trimmingIndex > 0) {
+					textArray[length] = lastSegment.slice(0, trimmingIndex);
+				}
+			}
+			return textArray.join("</p>") + "...";
+		} else {
+			return text;
+		}
+	}
 </script>
 
 <template lang="pug">
@@ -72,7 +91,7 @@ Here's some documentation for this component.
 					p.mb-4.text-17.italic.opacity-80.text-neutral-100 { data?.article.excerpt }
 					//- prettier-ignore
 					#article-text.text-18.leading-relaxed.mb-8(class="md:text-[18px]")
-						+html('data.article?.text?.html?.substring(0,1200) ?? "" + "... " ')
+						+html('onPageArticleBody ?? "" + "... " ')
 
 						i.opacity-80.text-16 ( article continues at { data.article?.source?.name ? data.article?.source?.name : "" } )
 


### PR DESCRIPTION
Adds programatic text editing to the individual news stories.

Every news article has been checked in both dev and build/preview modes and no bugs were spotted.

The master function, truncateArticleText, contains one helper function per bulleted item to do the following:

- apply the character limit to the raw text
- raise the character limit for anchor element code in the source text--anchor element code doesn't appear on the page but it DOES deplete the character allowance (this helper recursively searches for additional anchor elements after each increase to the character limit)
- clean the end of the last paragraph to make the ending ellipsis and its application uniform

The body of the master function also eliminates partial paragraphs in cases where there is more than one paragraph in the array that is made from the character-limited text, and it removes empty paragraphs that can result from extra carriage returns entered into the Hygraph interface.